### PR TITLE
Configure Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.phive          export-ignore
+/tests           export-ignore
+/tools           export-ignore
+/tools/*         binary
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/infection.json5 export-ignore
+/phpunit.xml     export-ignore
+
+*.php diff=php


### PR DESCRIPTION
This introduces a `.gitattributes` file to configure Git, most importantly which files and directories to ignore when an archive is created for a tag.